### PR TITLE
 getServiceName with 0.13.0 

### DIFF
--- a/packages/moleculer-jaeger/src/index.js
+++ b/packages/moleculer-jaeger/src/index.js
@@ -6,13 +6,13 @@
 
 "use strict";
 
-const _ 			= require("lodash");
-const Jaeger 		= require("jaeger-client");
+const _ = require("lodash");
+const Jaeger = require("jaeger-client");
 const GuaranteedThroughputSampler = require("jaeger-client/dist/src/samplers/guaranteed_throughput_sampler").default;
 const RemoteControlledSampler = require("jaeger-client/dist/src/samplers/remote_sampler").default;
-const UDPSender 	= require("jaeger-client/dist/src/reporters/udp_sender").default;
+const UDPSender = require("jaeger-client/dist/src/reporters/udp_sender").default;
 
-const Int64 		= require("node-int64");
+const Int64 = require("node-int64");
 
 /**
  * Moleculer metrics module for Jaeger.
@@ -74,8 +74,11 @@ module.exports = {
 		 * @returns {String}
 		 */
 		getServiceName(metric) {
-			if (metric.service)
+			if (metric.service) {
+				if (metric.service.name)
+					return metric.service.name;
 				return metric.service;
+			}
 
 			let parts = metric.action.name.split(".");
 			parts.pop();
@@ -189,7 +192,7 @@ module.exports = {
 		 */
 		convertID(id) {
 			if (id) {
-				return new Int64(id.replace(/-/g, "").substring(0,16)).toBuffer();
+				return new Int64(id.replace(/-/g, "").substring(0, 16)).toBuffer();
 			}
 			return null;
 		},
@@ -222,7 +225,7 @@ module.exports = {
 		 *
 		 */
 		getReporter() {
-			return new Jaeger.RemoteReporter(new UDPSender({host: this.settings.host, port: this.settings.port }));
+			return new Jaeger.RemoteReporter(new UDPSender({ host: this.settings.host, port: this.settings.port }));
 		},
 
 		/**

--- a/packages/moleculer-zipkin/src/index.js
+++ b/packages/moleculer-zipkin/src/index.js
@@ -72,8 +72,11 @@ module.exports = {
 		 * @returns {String}
 		 */
 		getServiceName(metric) {
-			if (metric.service)
+			if (metric.service) {
+				if (metric.service.name)
+					return metric.service.name;
 				return metric.service;
+			}
 
 			let parts = metric.action.name.split(".");
 			parts.pop();
@@ -180,11 +183,11 @@ module.exports = {
 				parentId: this.convertID(metric.parent),
 
 				localEndpoint: {
-					serviceName: serviceName.name ? serviceName.name : serviceName,
+					serviceName: serviceName,
 				},
 
 				remoteEndpoint: {
-					serviceName: serviceName.name ? serviceName.name : serviceName,
+					serviceName: serviceName,
 				},
 
 				annotations: [

--- a/packages/moleculer-zipkin/src/index.js
+++ b/packages/moleculer-zipkin/src/index.js
@@ -126,10 +126,10 @@ module.exports = {
 
 				// Binary annotations
 				binaryAnnotations: [
-					{ key: "nodeID", 		value: metric.nodeID },
-					{ key: "level", 		value: metric.level.toString() },
-					{ key: "remoteCall", 	value: metric.remoteCall.toString() },
-					{ key: "callerNodeID", 	value: metric.callerNodeID ? metric.callerNodeID : "" }
+					{ key: "nodeID", value: metric.nodeID },
+					{ key: "level", value: metric.level.toString() },
+					{ key: "remoteCall", value: metric.remoteCall.toString() },
+					{ key: "callerNodeID", value: metric.callerNodeID ? metric.callerNodeID : "" }
 				],
 
 				timestamp: this.convertTime(metric.endTime)
@@ -180,11 +180,11 @@ module.exports = {
 				parentId: this.convertID(metric.parent),
 
 				localEndpoint: {
-					serviceName: serviceName,
+					serviceName: serviceName.name ? serviceName.name : serviceName,
 				},
 
 				remoteEndpoint: {
-					serviceName: serviceName,
+					serviceName: serviceName.name ? serviceName.name : serviceName,
 				},
 
 				annotations: [
@@ -201,7 +201,7 @@ module.exports = {
 				},
 
 				timestamp: this.convertTime(metric.startTime),
-				durationMicros: Math.round(metric.duration * 1000),
+				duration: Math.round(metric.duration * 1000),
 
 				debug: this.settings.payloadOptions.debug,
 				shared: this.settings.payloadOptions.shared
@@ -322,7 +322,7 @@ module.exports = {
 		 * @returns {String}
 		 */
 		convertID(id) {
-			return id ? id.replace(/-/g, "").substring(0,16) : null;
+			return id ? id.replace(/-/g, "").substring(0, 16) : null;
 		},
 
 		/**


### PR DESCRIPTION
getServiceName function work with moleculer 0.13.0 should return a string , not {name:"demo"}