### PR TITLE
fix: jaeger/zipkin add tags null/undefined value

### DIFF
--- a/packages/moleculer-jaeger/src/index.js
+++ b/packages/moleculer-jaeger/src/index.js
@@ -174,7 +174,7 @@ module.exports = {
 		 */
 		addTags(span, key, value, prefix) {
 			const name = prefix ? `${prefix}.${key}` : key;
-			if (typeof value == "object") {
+			if (value && typeof value == "object") {
 				Object.keys(value).forEach(k => this.addTags(span, k, value[k], name));
 			} else {
 				span.setTag(name, value);

--- a/packages/moleculer-jaeger/test/unit/index.spec.js
+++ b/packages/moleculer-jaeger/test/unit/index.spec.js
@@ -136,6 +136,25 @@ describe("Test payload creating", () => {
 		});
 	});
 
+	it("test addTags method with null", () => {
+		const span = { setTag: jest.fn((name, value) => span[name] = value) };
+		service.addTags(span, "first", null);
+
+		expect(span).toEqual({
+			"first": null,
+			setTag: jasmine.any(Function)
+		});
+	});
+
+	it("test addTags method with undefined", () => {
+		const span = { setTag: jest.fn((name, value) => span[name] = value) };
+		service.addTags(span, "first", undefined);
+
+		expect(span).toEqual({
+			setTag: jasmine.any(Function)
+		});
+	});
+
 	it("test addTags method with object", () => {
 		const span = { setTag: jest.fn((name, value) => span[name] = value) };
 		service.addTags(span, "first", { a: 5, b: { c: "John", d: true }});

--- a/packages/moleculer-zipkin/src/index.js
+++ b/packages/moleculer-zipkin/src/index.js
@@ -308,9 +308,9 @@ module.exports = {
 		 */
 		addTags(payload, key, value, prefix) {
 			const name = prefix ? `${prefix}.${key}` : key;
-			if (typeof value == "object") {
+			if (value && typeof value == "object") {
 				Object.keys(value).forEach(k => this.addTags(payload, k, value[k], name));
-			} else {
+			} else if (value !== undefined) {
 				payload.tags[name] = String(value);
 			}
 		},

--- a/packages/moleculer-zipkin/test/unit/index.spec.js
+++ b/packages/moleculer-zipkin/test/unit/index.spec.js
@@ -455,6 +455,26 @@ describe("Test v2 payload creating", () => {
 		});
 	});
 
+	it("test addTags method with null", () => {
+		const payload = { tags: {} };
+		service.addTags(payload, "first", null);
+
+		expect(payload).toEqual({
+			tags: {
+				first: "null"
+			}
+		});
+	});
+
+	it("test addTags method with undefined", () => {
+		const payload = { tags: {} };
+		service.addTags(payload, "first", undefined);
+
+		expect(payload).toEqual({
+			tags: { }
+		});
+	});
+
 	it("test addTags method with object", () => {
 		const payload = { tags: {} };
 		service.addTags(payload, "first", { a: 5, b: { c: "John", d: true }});


### PR DESCRIPTION
I was getting strange error with jaeger : 
![image](https://user-images.githubusercontent.com/1301995/55192234-4aa00c00-51a4-11e9-9dac-ebcb4ae57b1d.png)
And it was because this is `true` :
```js
typeof null === 'object'
```
And then the `Object.keys(value)` in the `addTags` throw an exception because of the `null` value
:heart:  JS