### PR TITLE
Fix for moleculer 0.14

### DIFF
--- a/packages/moleculer-prometheus/src/index.js
+++ b/packages/moleculer-prometheus/src/index.js
@@ -176,7 +176,7 @@ module.exports = {
 
 			return this.broker.mcall({
 				nodes: { action: "$node.list" },
-				services: { action: "$node.services", params: { withActions: false, skipInternal: true } },
+				services: { action: "$node.services", params: { withActions: false, grouping: true, skipInternal: true } },
 				actions: { action: "$node.actions", params: { withEndpoints: true, skipInternal: true } },
 				events: { action: "$node.events", params: { withEndpoints: true, skipInternal: true } }
 			}).then(({ nodes, services, actions, events}) => {

--- a/packages/moleculer-prometheus/test/unit/index.spec.js
+++ b/packages/moleculer-prometheus/test/unit/index.spec.js
@@ -352,7 +352,7 @@ describe("Test updateCommonValues method", () => {
 			expect(broker.mcall).toHaveBeenCalledTimes(1);
 			expect(broker.mcall).toHaveBeenCalledWith({
 				nodes: { action: "$node.list" },
-				services: { action: "$node.services", params: { withActions: false, skipInternal: true } },
+				services: { action: "$node.services", params: { withActions: false, grouping: true, skipInternal: true } },
 				actions: { action: "$node.actions", params: { withEndpoints: true, skipInternal: true } },
 				events: { action: "$node.events", params: { withEndpoints: true, skipInternal: true } }
 			});


### PR DESCRIPTION
`$node.services` response has no `nodes` property by default, so I've added `grouping: true` param to  still receive it.

btw looks like test don't cover this change. let me know what else I can do.