### PR TITLE
Allow configuration of Prometheus hostname

### DIFF
--- a/packages/moleculer-prometheus/README.md
+++ b/packages/moleculer-prometheus/README.md
@@ -87,6 +87,7 @@ broker.broadcast("metrics.update", {
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `port` | `Number` | `3030` | Exposed HTTP port. |
+| `hostname` | `String` | `localhost` | Exposed HTTP hostname. |
 | `collectDefaultMetrics` | `Boolean` | `true` | Enable to collect default metrics. |
 | `timeout` | `Number` | `10000` | Timeout option for 'collectDefaultMetrics' in milliseconds. |
 | `metrics` | `Object` | `{}` | Metric definitions. |

--- a/packages/moleculer-prometheus/src/index.js
+++ b/packages/moleculer-prometheus/src/index.js
@@ -39,6 +39,9 @@ module.exports = {
 	 * Default settings
 	 */
 	settings: {
+		/** @type {String} Exposed HTTP hostname. */
+		hostname: "localhost",
+		
 		/** @type {Number} Exposed HTTP port. */
 		port: 3030,
 
@@ -243,8 +246,8 @@ module.exports = {
 			res.end(this.register.metrics());
 		});
 
-		return this.server.listen(this.settings.port).then(() => {
-			this.logger.info(`Prometheus collector is listening on port ${this.settings.port}, metrics exposed on /metrics endpoint`);
+		return this.server.listen(this.settings.port, this.settings.hostname).then(() => {
+			this.logger.info(`Prometheus collector is listening on ${this.settings.hostname}:${this.settings.port}, metrics exposed on /metrics endpoint`);
 
 			this.updateCommonValues();
 		});

--- a/packages/moleculer-prometheus/test/unit/index.spec.js
+++ b/packages/moleculer-prometheus/test/unit/index.spec.js
@@ -63,7 +63,7 @@ describe("Test PromService started & stopped", () => {
 			expect(MockPolka.get).toHaveBeenCalledWith("/metrics", jasmine.any(Function));
 
 			expect(MockPolka.listen).toHaveBeenCalledTimes(1);
-			expect(MockPolka.listen).toHaveBeenCalledWith(3030);
+			expect(MockPolka.listen).toHaveBeenCalledWith(3030, "localhost");
 		});
 
 		it("should set res header and content", () => {
@@ -99,7 +99,8 @@ describe("Test PromService started & stopped", () => {
 		it("change settings", () => {
 			service.settings = {
 				collectDefaultMetrics: false,
-				port: 4567
+				port: 4567,
+				hostname: "0.0.0.0"
 			};
 
 			service.createMetrics = jest.fn();
@@ -125,7 +126,7 @@ describe("Test PromService started & stopped", () => {
 			expect(MockPolka.get).toHaveBeenCalledWith("/metrics", jasmine.any(Function));
 
 			expect(MockPolka.listen).toHaveBeenCalledTimes(1);
-			expect(MockPolka.listen).toHaveBeenCalledWith(4567);
+			expect(MockPolka.listen).toHaveBeenCalledWith(4567, "0.0.0.0");
 		});
 
 		it("should not destroy timer", () => {


### PR DESCRIPTION
In some cases it is necessary to expose the server on more than just localhost. This adds a configuration for exactly that.